### PR TITLE
ignore case of reply header names, as per RFC 7230

### DIFF
--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -59,7 +59,7 @@ function(curl = getCurlHandle(), txt = character(), max = NA, value = NULL, verb
             content.type <<- getContentType(http.header, TRUE)
 
             if(is.na(binary))
-               binary = isBinaryContent(http.header, list(http.header["Content-Encoding"], content.type) )
+               binary = isBinaryContent(http.header, list(http.header["content-encoding"], content.type) )
           
 
              # This happens when we get a "HTTP/1.1 100 Continue\r\n" and then

--- a/R/header.R
+++ b/R/header.R
@@ -48,7 +48,7 @@ function(lines, multi = TRUE)
 #   header <- sapply(els, function(x) paste(x[2]) #XX what if more than 2 els.
 #   names(header) <- sapply(els, function(x) x[1])
    header = structure(sub("[^:]+: (.*)", "\\1", lines),
-                      names = sub("([^:]+):.*", "\\1", lines))
+                      names = tolower(sub("([^:]+):.*", "\\1", lines)))
  }
 
 # st = getStatus(status)


### PR DESCRIPTION
This change fixes the problem that a reply with this header:
```
Content-encoding: bzip2
```
is not recognized as being bzip2-compressed, while one with this header:
```
Content-Encoding: bzip2
```
**is**.
