### PR TITLE
add CURLOPT_HTTP200ALIASES to options requiring a `curl_slist` param

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -777,6 +777,7 @@ getCurlPointerForData(SEXP el, CURLoption option, Rboolean isProtected, CURL *cu
 		    if(option == CURLOPT_HTTPHEADER ||
                        option == CURLOPT_QUOTE || 
                        option == CURLOPT_PREQUOTE ||
+                       option == CURLOPT_HTTP200ALIASES ||
                        option == CURLOPT_POSTQUOTE) {
 
                                    /* struct curl_slist */


### PR DESCRIPTION
Otherwise:
```R
library(RCurl)
Loading required package: bitops
> httpGET("https://google.com", .opts=list(HTTP200ALIASES="Icy 200 Okay"))
 *** caught segfault ***
```

The same problem was recently fixed in package `curl`:
https://github.com/jeroen/curl/pull/142